### PR TITLE
Update poolWorker.js

### DIFF
--- a/libs/poolWorker.js
+++ b/libs/poolWorker.js
@@ -164,6 +164,9 @@ module.exports = function(logger){
         var pool = Stratum.createPool(poolOptions, authorizeFN, logger);
         pool.on('share', function(isValidShare, isValidBlock, data){
             
+			if(data.worker != undefined)
+				data.worker = data.worker.replace(/:/g,"-")           
+            
             var shareData = JSON.stringify(data);
             
             if (data.blockHash && !isValidBlock)


### PR DESCRIPTION
1: Fix that the mining machine number with colon in the mining address will not produce blocks. For example, use the mac address as the mining machine number, etc.
2: One of the ways to fix the block attack